### PR TITLE
Cmo api

### DIFF
--- a/include/owb.h
+++ b/include/owb.h
@@ -23,7 +23,7 @@
  */
 
 /**
- * @file owb.h
+ * @file
  * @brief Interface definitions for the 1-Wire bus component.
  *
  * This component provides structures and functions that are useful for communicating

--- a/include/owb.h
+++ b/include/owb.h
@@ -94,6 +94,13 @@ typedef struct
     int last_device_flag;
 } OneWireBus_SearchState;
 
+typedef enum
+{
+    OWB_STATUS_OK,
+    OWB_STATUS_NOT_INITIALIZED,
+    OWB_STATUS_ERR
+} owb_status;
+
 /**
  * @brief Construct a new 1-Wire bus instance.
  *        New instance should be initialised before calling other functions.
@@ -112,76 +119,84 @@ void owb_free(OneWireBus ** bus);
  * @brief Initialise a 1-Wire bus instance with the specified GPIO.
  * @param[in] bus Pointer to bus instance.
  * @param[in] gpio GPIO number to associate with device.
+ * @return status
  */
-void owb_init(OneWireBus * bus, int gpio);
+owb_status owb_init(OneWireBus * bus, int gpio);
 
 /**
  * @brief Enable or disable use of CRC checks on device communications.
  * @param[in] bus Pointer to initialised bus instance.
  * @param[in] use_crc True to enable CRC checks, false to disable.
+ * @return status
  */
-void owb_use_crc(OneWireBus * bus, bool use_crc);
+owb_status owb_use_crc(OneWireBus * bus, bool use_crc);
 
 /**
  * @brief Read ROM code from device - only works when there is a single device on the bus.
  * @param[in] bus Pointer to initialised bus instance.
- * @return The value read from the device's ROM.
+ * @param[out] rom_code the value read from the device's rom
+ * @return status
  */
-OneWireBus_ROMCode owb_read_rom(const OneWireBus * bus);
+owb_status owb_read_rom(const OneWireBus * bus, OneWireBus_ROMCode *rom_code);
 
 /**
  * @brief Verify the device specified by ROM code is present.
  * @param[in] bus Pointer to initialised bus instance.
  * @param[in] rom_code ROM code to verify.
- * @return true if device is present, false if not present.
+ * @param[out] is_present set to true if a device is present, false if not
+ * @return status
  */
-bool owb_verify_rom(const OneWireBus * bus, OneWireBus_ROMCode rom_code);
+owb_status owb_verify_rom(const OneWireBus * bus, OneWireBus_ROMCode rom_code, bool* is_present);
 
 /**
  * @brief Reset the 1-Wire bus.
  * @param[in] bus Pointer to initialised bus instance.
- * @return True if at least one device is present on the bus.
+ * @param[out] is_present set to true if at least one device is present on the bus
+ * @return status
  */
-bool owb_reset(const OneWireBus * bus);
+owb_status owb_reset(const OneWireBus * bus, bool* a_device_present);
 
 /**
  * @brief Write a single byte to the 1-Wire bus.
  * @param[in] bus Pointer to initialised bus instance.
  * @param[in] data Byte value to write to bus.
+ * @return status
  */
-void owb_write_byte(const OneWireBus * bus, uint8_t data);
+owb_status owb_write_byte(const OneWireBus * bus, uint8_t data);
 
 /**
  * @brief Read a single byte from the 1-Wire bus.
  * @param[in] bus Pointer to initialised bus instance.
- * @return The byte value read from the bus.
+ * @param[out] out The byte value read from the bus.
+ * @return status
  */
-uint8_t owb_read_byte(const OneWireBus * bus);
+owb_status owb_read_byte(const OneWireBus * bus, uint8_t *out);
 
 /**
  * @brief Read a number of bytes from the 1-Wire bus.
  * @param[in] bus Pointer to initialised bus instance.
  * @param[in, out] buffer Pointer to buffer to receive read data.
  * @param[in] len Number of bytes to read, must not exceed length of receive buffer.
- * @return Pointer to receive buffer.
+ * @return status.
  */
-uint8_t * owb_read_bytes(const OneWireBus * bus, uint8_t * buffer, size_t len);
+owb_status owb_read_bytes(const OneWireBus * bus, uint8_t * buffer, size_t len);
 
 /**
  * @brief Write a number of bytes to the 1-Wire bus.
  * @param[in] bus Pointer to initialised bus instance.
  * @param[in] buffer Pointer to buffer to write data from.
  * @param[in] len Number of bytes to write.
- * @return Pointer to write buffer.
+ * @return status
  */
-const uint8_t * owb_write_bytes(const OneWireBus * bus, const uint8_t * buffer, size_t len);
+owb_status owb_write_bytes(const OneWireBus * bus, const uint8_t * buffer, size_t len);
 
 /**
  * @brief Write a ROM code to the 1-Wire bus ensuring LSB is sent first.
  * @param[in] bus Pointer to initialised bus instance.
  * @param[in] rom_code ROM code to write to bus.
+ * @return status
  */
-void owb_write_rom_code(const OneWireBus * bus, OneWireBus_ROMCode rom_code);
+owb_status owb_write_rom_code(const OneWireBus * bus, OneWireBus_ROMCode rom_code);
 
 /**
  * @brief 1-Wire 8-bit CRC lookup.
@@ -206,20 +221,22 @@ uint8_t owb_crc8_bytes(uint8_t crc, const uint8_t * data, size_t len);
  * @brief Locates the first device on the 1-Wire bus, if present.
  * @param[in] bus Pointer to initialised bus instance.
  * @param[in,out] state Pointer to an existing search state structure.
- * @return True if a device is found, false if no devices are found.
+ * @param[out] found_device True if a device is found, false if no devices are found.
  *         If a device is found, the ROM Code can be obtained from the state.
+ * @return status
  */
-bool owb_search_first(const OneWireBus * bus, OneWireBus_SearchState * state);
+owb_status owb_search_first(const OneWireBus * bus, OneWireBus_SearchState * state, bool *found_device);
 
 /**
  * @brief Locates the next device on the 1-Wire bus, if present, starting from
  *        the provided state. Further calls will yield additional devices, if present.
  * @param[in] bus Pointer to initialised bus instance.
  * @param[in,out] state Pointer to an existing search state structure.
- * @return True if a device is found, false if no devices are found.
+ * @param[out] found_device True if a device is found, false if no devices are found.
  *         If a device is found, the ROM Code can be obtained from the state.
+ * @return status
  */
-bool owb_search_next(const OneWireBus * bus, OneWireBus_SearchState * state);
+owb_status owb_search_next(const OneWireBus * bus, OneWireBus_SearchState * state, bool *found_device);
 
 /**
  * @brief Create a string representation of a ROM code.
@@ -227,6 +244,7 @@ bool owb_search_next(const OneWireBus * bus, OneWireBus_SearchState * state);
  * @param[out] buffer The destination for the string representation. It will be null terminated.
  * @param[in] len The length of the buffer in bytes. 64-bit ROM codes require 16 characters
  *                to represent as a string, plus a null terminator, for 17 bytes.
+ * @return pointer to the byte beyond the last byte written
  */
 char * owb_string_from_rom_code(OneWireBus_ROMCode rom_code, char * buffer, size_t len);
 

--- a/include/owb.h
+++ b/include/owb.h
@@ -58,7 +58,6 @@ struct owb_driver;
  */
 typedef struct
 {
-    int gpio;                                   ///< Value of GPIO connected to 1-Wire bus
     const struct _OneWireBus_Timing * timing;   ///< Pointer to timing information
     bool use_crc;                               ///< True if CRC checks are to be used when retrieving information from a device on the bus
 
@@ -115,6 +114,10 @@ struct owb_driver
     owb_status (*write_bytes)(const OneWireBus * bus, const uint8_t *buf, size_t count);
     owb_status (*read_bytes)(const OneWireBus * bus, uint8_t *buf, size_t count);
 };
+
+#define container_of(ptr, type, member) ({                      \
+        const typeof( ((type *)0)->member ) *__mptr = (ptr);    \
+        (type *)( (char *)__mptr - offsetof(type,member) );})
 
 /**
  * @brief Construct a new 1-Wire bus instance.

--- a/owb.c
+++ b/owb.c
@@ -23,7 +23,7 @@
  */
 
 /**
- * @file owb.c
+ * @file
  */
 
 #include <stddef.h>

--- a/owb.c
+++ b/owb.c
@@ -2,6 +2,7 @@
  * MIT License
  *
  * Copyright (c) 2017 David Antliff
+ * Copyright (c) 2017 Chris Morgan <chmorgan@gmail.com>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -39,56 +40,16 @@
 #include "driver/gpio.h"
 
 #include "owb.h"
+#include "owb_gpio.h"
 
 static const char * TAG = "owb";
 
-// Define PHY_DEBUG to enable GPIO output around when the bus is sampled
-// by the master (this library). This GPIO output makes it possible to
-// validate the master's sampling using an oscilloscope.
-//
-// For the debug GPIO the idle state is low and made high before the 1-wire sample
-// point and low again after the sample point
-#undef PHY_DEBUG
-
-#ifdef PHY_DEBUG
-// Update these defines to a pin that you can access
-#define PHY_DEBUG_GPIO GPIO_NUM_27
-#define PHY_DEBUG_GPIO_MASK GPIO_SEL_27
-#endif
-
-/// @cond ignore
-struct _OneWireBus_Timing
-{
-    uint32_t A, B, C, D, E, F, G, H, I, J;
-};
-//// @endcond
-
-// 1-Wire timing delays (standard) in microseconds.
-// Labels and values are from https://www.maximintegrated.com/en/app-notes/index.mvp/id/126
-static const struct _OneWireBus_Timing _StandardTiming = {
-        6,    // A - read/write "1" master pull DQ low duration
-        64,   // B - write "0" master pull DQ low duration
-        60,   // C - write "1" master pull DQ high duration
-        10,   // D - write "0" master pull DQ high duration
-        9,    // E - read master pull DQ high duration
-        55,   // F - complete read timeslot + 10ms recovery
-        0,    // G - wait before reset
-        480,  // H - master pull DQ low duration
-        70,   // I - master pull DQ high duration
-        410,  // J - complete presence timeslot + recovery
-};
-
-static void _us_delay(uint32_t time_us)
-{
-    ets_delay_us(time_us);
-}
-
-bool _is_init(const OneWireBus * bus)
+static bool _is_init(const OneWireBus * bus)
 {
     bool ok = false;
     if (bus != NULL)
     {
-        if (bus->init)
+        if (bus->driver)
         {
             // OK
             ok = true;
@@ -103,193 +64,6 @@ bool _is_init(const OneWireBus * bus)
         ESP_LOGE(TAG, "bus is NULL");
     }
     return ok;
-}
-
-/**
- * @brief Generate a 1-Wire reset (initialization).
- * @param[in] bus Initialised bus instance.
- * @return true if device is present, otherwise false.
- */
-static bool _reset(const OneWireBus * bus)
-{
-    bool present = false;
-    if (_is_init(bus))
-    {
-        portMUX_TYPE timeCriticalMutex = portMUX_INITIALIZER_UNLOCKED;
-        taskENTER_CRITICAL(&timeCriticalMutex);
-
-        gpio_set_direction(bus->gpio, GPIO_MODE_OUTPUT);
-        _us_delay(bus->timing->G);
-        gpio_set_level(bus->gpio, 0);  // Drive DQ low
-        _us_delay(bus->timing->H);
-        gpio_set_direction(bus->gpio, GPIO_MODE_INPUT); // Release the bus
-        gpio_set_level(bus->gpio, 1);  // Reset the output level for the next output
-        _us_delay(bus->timing->I);
-
-#ifdef PHY_DEBUG
-        gpio_set_level(PHY_DEBUG_GPIO, 1);
-#endif
-
-        int level1 = gpio_get_level(bus->gpio);
-
-#ifdef PHY_DEBUG
-        gpio_set_level(PHY_DEBUG_GPIO, 0);
-#endif
-
-        _us_delay(bus->timing->J);   // Complete the reset sequence recovery
-
-#ifdef PHY_DEBUG
-        gpio_set_level(PHY_DEBUG_GPIO, 1);
-#endif
-
-        int level2 = gpio_get_level(bus->gpio);
-
-#ifdef PHY_DEBUG
-        gpio_set_level(PHY_DEBUG_GPIO, 0);
-#endif
-
-        taskEXIT_CRITICAL(&timeCriticalMutex);
-
-        present = (level1 == 0) && (level2 == 1);   // Sample for presence pulse from slave
-        ESP_LOGD(TAG, "reset: level1 0x%x, level2 0x%x, present %d", level1, level2, present);
-    }
-    return present;
-}
-
-/**
- * @brief Send a 1-Wire write bit, with recovery time.
- * @param[in] bus Initialised bus instance.
- * @param[in] bit The value to send.
- */
-static void _write_bit(const OneWireBus * bus, int bit)
-{
-    if (_is_init(bus))
-    {
-        int delay1 = bit ? bus->timing->A : bus->timing->C;
-        int delay2 = bit ? bus->timing->B : bus->timing->D;
-
-        portMUX_TYPE timeCriticalMutex = portMUX_INITIALIZER_UNLOCKED;
-        taskENTER_CRITICAL(&timeCriticalMutex);
-
-        gpio_set_direction(bus->gpio, GPIO_MODE_OUTPUT);
-        gpio_set_level(bus->gpio, 0);  // Drive DQ low
-        _us_delay(delay1);
-        gpio_set_level(bus->gpio, 1);  // Release the bus
-        _us_delay(delay2);
-
-        taskEXIT_CRITICAL(&timeCriticalMutex);
-    }
-}
-
-/**
- * @brief Read a bit from the 1-Wire bus and return the value, with recovery time.
- * @param[in] bus Initialised bus instance.
- */
-static int _read_bit(const OneWireBus * bus)
-{
-    int result = 0;
-    if (_is_init(bus))
-    {
-        portMUX_TYPE timeCriticalMutex = portMUX_INITIALIZER_UNLOCKED;
-        taskENTER_CRITICAL(&timeCriticalMutex);
-
-        gpio_set_direction(bus->gpio, GPIO_MODE_OUTPUT);
-        gpio_set_level(bus->gpio, 0);  // Drive DQ low
-        _us_delay(bus->timing->A);
-        gpio_set_direction(bus->gpio, GPIO_MODE_INPUT); // Release the bus
-        gpio_set_level(bus->gpio, 1);  // Reset the output level for the next output
-        _us_delay(bus->timing->E);
-
-#ifdef PHY_DEBUG
-        gpio_set_level(PHY_DEBUG_GPIO, 1);
-#endif
-
-        int level = gpio_get_level(bus->gpio);
-
-#ifdef PHY_DEBUG
-        gpio_set_level(PHY_DEBUG_GPIO, 0);
-#endif
-
-        _us_delay(bus->timing->F);   // Complete the timeslot and 10us recovery
-
-        taskEXIT_CRITICAL(&timeCriticalMutex);
-
-        result = level & 0x01;
-    }
-    return result;
-}
-
-/**
- * @brief Write 1-Wire data byte.
- * @param[in] bus Initialised bus instance.
- * @param[in] data Value to write.
- */
-static void _write_byte(const OneWireBus * bus, uint8_t data)
-{
-    if (_is_init(bus))
-    {
-        ESP_LOGD(TAG, "write 0x%02x", data);
-        for (int i = 0; i < 8; ++i)
-        {
-            _write_bit(bus, data & 0x01);
-            data >>= 1;
-        }
-    }
-}
-
-/**
- * @brief Read 1-Wire data byte from  bus.
- * @param[in] bus Initialised bus instance.
- * @return Byte value read from bus.
- */
-static uint8_t _read_byte(const OneWireBus * bus)
-{
-    uint8_t result = 0;
-    if (_is_init(bus))
-    {
-        for (int i = 0; i < 8; ++i)
-        {
-            result >>= 1;
-            if (_read_bit(bus))
-            {
-                result |= 0x80;
-            }
-        }
-        ESP_LOGD(TAG, "read 0x%02x", result);
-    }
-    return result;
-}
-
-/**
- * @param Read a block of bytes from 1-Wire bus.
- * @param[in] bus Initialised bus instance.
- * @param[in,out] buffer Pointer to buffer to receive read data.
- * @param[in] len Number of bytes to read, must not exceed length of receive buffer.
- * @return Pointer to receive buffer.
- */
-static uint8_t * _read_block(const OneWireBus * bus, uint8_t * buffer, unsigned int len)
-{
-    for (int i = 0; i < len; ++i)
-    {
-        *buffer++ = _read_byte(bus);
-    }
-    return buffer;
-}
-
-/**
- * @param Write a block of bytes from 1-Wire bus.
- * @param[in] bus Initialised bus instance.
- * @param[in] buffer Pointer to buffer to write data from.
- * @param[in] len Number of bytes to write.
- * @return Pointer to write buffer.
- */
-static const uint8_t * _write_block(const OneWireBus * bus, const uint8_t * buffer, unsigned int len)
-{
-    for (int i = 0; i < len; ++i)
-    {
-        _write_byte(bus, buffer[i]);
-    }
-    return buffer;
 }
 
 /**
@@ -334,129 +108,6 @@ static uint8_t _calc_crc_block(uint8_t crc, const uint8_t * buffer, size_t len)
     return crc;
 }
 
-/* @return true if a device was found, false if not */
-static bool _search(const OneWireBus * bus, OneWireBus_SearchState * state)
-{
-    // Based on https://www.maximintegrated.com/en/app-notes/index.mvp/id/187
-
-    // initialize for search
-    int id_bit_number = 1;
-    int last_zero = 0;
-    int rom_byte_number = 0;
-    int id_bit = 0;
-    int cmp_id_bit = 0;
-    uint8_t rom_byte_mask = 1;
-    uint8_t search_direction = 0;
-    bool search_result = false;
-    uint8_t crc8 = 0;
-
-    if (_is_init(bus))
-    {
-        // if the last call was not the last one
-        if (!state->last_device_flag)
-        {
-            // 1-Wire reset
-            if (!_reset(bus))
-            {
-                // reset the search
-                state->last_discrepancy = 0;
-                state->last_device_flag = false;
-                state->last_family_discrepancy = 0;
-                return false;
-            }
-
-            // issue the search command
-            _write_byte(bus, OWB_ROM_SEARCH);
-
-            // loop to do the search
-            do
-            {
-                // read a bit and its complement
-                id_bit = _read_bit(bus);
-                cmp_id_bit = _read_bit(bus);
-
-                // check for no devices on 1-wire
-                if ((id_bit == 1) && (cmp_id_bit == 1))
-                    break;
-                else
-                {
-                    // all devices coupled have 0 or 1
-                    if (id_bit != cmp_id_bit)
-                        search_direction = id_bit;  // bit write value for search
-                    else
-                    {
-                        // if this discrepancy if before the Last Discrepancy
-                        // on a previous next then pick the same as last time
-                        if (id_bit_number < state->last_discrepancy)
-                            search_direction = ((state->rom_code.bytes[rom_byte_number] & rom_byte_mask) > 0);
-                        else
-                            // if equal to last pick 1, if not then pick 0
-                            search_direction = (id_bit_number == state->last_discrepancy);
-
-                        // if 0 was picked then record its position in LastZero
-                        if (search_direction == 0)
-                        {
-                            last_zero = id_bit_number;
-
-                            // check for Last discrepancy in family
-                            if (last_zero < 9)
-                                state->last_family_discrepancy = last_zero;
-                        }
-                    }
-
-                    // set or clear the bit in the ROM byte rom_byte_number
-                    // with mask rom_byte_mask
-                    if (search_direction == 1)
-                        state->rom_code.bytes[rom_byte_number] |= rom_byte_mask;
-                    else
-                        state->rom_code.bytes[rom_byte_number] &= ~rom_byte_mask;
-
-                    // serial number search direction write bit
-                    _write_bit(bus, search_direction);
-
-                    // increment the byte counter id_bit_number
-                    // and shift the mask rom_byte_mask
-                    id_bit_number++;
-                    rom_byte_mask <<= 1;
-
-                    // if the mask is 0 then go to new SerialNum byte rom_byte_number and reset mask
-                    if (rom_byte_mask == 0)
-                    {
-                        crc8 = _calc_crc(crc8, state->rom_code.bytes[rom_byte_number]);  // accumulate the CRC
-                        rom_byte_number++;
-                        rom_byte_mask = 1;
-                    }
-                }
-            }
-            while(rom_byte_number < 8);  // loop until through all ROM bytes 0-7
-
-            // if the search was successful then
-            if (!((id_bit_number < 65) || (crc8 != 0)))
-            {
-                // search successful so set LastDiscrepancy,LastDeviceFlag,search_result
-                state->last_discrepancy = last_zero;
-
-                // check for last device
-                if (state->last_discrepancy == 0)
-                    state->last_device_flag = true;
-
-                search_result = true;
-            }
-        }
-
-        // if no device found then reset counters so next 'search' will be like a first
-        if (!search_result || !state->rom_code.bytes[0])
-        {
-            state->last_discrepancy = 0;
-            state->last_device_flag = false;
-            state->last_family_discrepancy = 0;
-            search_result = false;
-        }
-    }
-    return search_result;
-}
-
-
 // Public API
 
 OneWireBus * owb_malloc()
@@ -488,32 +139,10 @@ owb_status owb_init(OneWireBus * bus, int gpio)
 {
     owb_status status;
 
-    if (bus != NULL)
-    {
-        bus->gpio = gpio;
-        bus->timing = &_StandardTiming;
-        bus->init = true;
+    // default to the gpio driver for now
+    bus->driver = owb_gpio_get_driver();
 
-        // platform specific:
-        gpio_pad_select_gpio(bus->gpio);
-
-#ifdef PHY_DEBUG
-        gpio_config_t io_conf;
-        io_conf.intr_type = GPIO_INTR_DISABLE;
-        io_conf.mode = GPIO_MODE_OUTPUT;
-        io_conf.pin_bit_mask = PHY_DEBUG_GPIO_MASK;
-        io_conf.pull_down_en = GPIO_PULLDOWN_ENABLE;
-        io_conf.pull_up_en = GPIO_PULLUP_DISABLE;
-        ESP_ERROR_CHECK(gpio_config(&io_conf));
-#endif
-
-        status = OWB_STATUS_OK;
-    }
-    else
-    {
-        ESP_LOGE(TAG, "bus is NULL");
-        status = OWB_STATUS_ERR;
-    }
+    status = bus->driver->init(bus, gpio);
 
     return status;
 }
@@ -544,10 +173,13 @@ owb_status owb_read_rom(const OneWireBus * bus, OneWireBus_ROMCode *rom_code)
 
     if (_is_init(bus))
     {
-        if (_reset(bus))
+        bool is_present;
+        bus->driver->reset(bus, &is_present);
+        if (is_present)
         {
-            _write_byte(bus, OWB_ROM_READ);
-            _read_block(bus, rom_code->bytes, sizeof(OneWireBus_ROMCode));
+            uint8_t value = OWB_ROM_READ;
+            bus->driver->write_bytes(bus, &value, sizeof(value));
+            bus->driver->read_bytes(bus, rom_code->bytes, sizeof(OneWireBus_ROMCode));
 
             if (bus->use_crc)
             {
@@ -590,7 +222,9 @@ owb_status owb_verify_rom(const OneWireBus * bus, OneWireBus_ROMCode rom_code, b
             .last_device_flag = false,
         };
 
-        if (_search(bus, &state))
+        bool is_found;
+        bus->driver->search(bus, &state, &is_found);
+        if (is_found)
         {
             result = true;
             for (int i = 0; i < sizeof(state.rom_code.bytes) && result; ++i)
@@ -618,7 +252,7 @@ owb_status owb_reset(const OneWireBus * bus, bool* a_device_present)
 
     if (_is_init(bus))
     {
-        *a_device_present = _reset(bus);
+        bus->driver->reset(bus, a_device_present);
         status = OWB_STATUS_OK;
     } else
     {
@@ -634,7 +268,7 @@ owb_status owb_write_byte(const OneWireBus * bus, uint8_t data)
 
     if (_is_init(bus))
     {
-        _write_byte(bus, data);
+        bus->driver->write_bytes(bus, &data, sizeof(data));
         status = OWB_STATUS_OK;
     } else
     {
@@ -650,7 +284,7 @@ owb_status owb_read_byte(const OneWireBus * bus, uint8_t *out)
 
     if (_is_init(bus))
     {
-        *out = _read_byte(bus);
+        bus->driver->read_bytes(bus, out, sizeof(uint8_t));
         status = OWB_STATUS_OK;
     } else
     {
@@ -666,7 +300,7 @@ owb_status owb_read_bytes(const OneWireBus * bus, uint8_t * buffer, unsigned int
 
     if (_is_init(bus))
     {
-        _read_block(bus, buffer, len);
+        bus->driver->read_bytes(bus, buffer, len);
         status = OWB_STATUS_OK;
     } else
     {
@@ -682,7 +316,7 @@ owb_status owb_write_bytes(const OneWireBus * bus, const uint8_t * buffer, unsig
 
     if (_is_init(bus))
     {
-        _write_block(bus, buffer, len);
+        bus->driver->write_bytes(bus, buffer, len);
         status = OWB_STATUS_OK;
     } else
     {
@@ -698,7 +332,7 @@ owb_status owb_write_rom_code(const OneWireBus * bus, OneWireBus_ROMCode rom_cod
 
     if (_is_init(bus))
     {
-        _write_block(bus, (uint8_t *)&rom_code, sizeof(rom_code));
+        bus->driver->write_bytes(bus, (uint8_t *)&rom_code, sizeof(rom_code));
         status = OWB_STATUS_OK;
     } else
     {
@@ -731,7 +365,7 @@ owb_status owb_search_first(const OneWireBus * bus, OneWireBus_SearchState * sta
             state->last_discrepancy = 0;
             state->last_family_discrepancy = 0;
             state->last_device_flag = false;
-            result = _search(bus, state);
+            bus->driver->search(bus, state, &result);
             status = OWB_STATUS_OK;
         }
         else
@@ -757,7 +391,7 @@ owb_status owb_search_next(const OneWireBus * bus, OneWireBus_SearchState * stat
     {
         if (state != NULL)
         {
-            result = _search(bus, state);
+            bus->driver->search(bus, state, &result);
             status = OWB_STATUS_OK;
         }
         else

--- a/owb_gpio.c
+++ b/owb_gpio.c
@@ -1,0 +1,443 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2017 David Antliff
+ * Copyright (c) 2017 Chris Morgan <chmorgan@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/**
+ * @file
+ */
+
+#include <stddef.h>
+#include <stdbool.h>
+#include <inttypes.h>
+#include <string.h>
+#include <stdlib.h>
+
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "esp_log.h"
+#include "sdkconfig.h"
+#include "driver/gpio.h"
+
+#include "owb.h"
+
+static const char * TAG = "owb_gpio";
+
+// Define PHY_DEBUG to enable GPIO output around when the bus is sampled
+// by the master (this library). This GPIO output makes it possible to
+// validate the master's sampling using an oscilloscope.
+//
+// For the debug GPIO the idle state is low and made high before the 1-wire sample
+// point and low again after the sample point
+#undef PHY_DEBUG
+
+#ifdef PHY_DEBUG
+// Update these defines to a pin that you can access
+#define PHY_DEBUG_GPIO GPIO_NUM_27
+#define PHY_DEBUG_GPIO_MASK GPIO_SEL_27
+#endif
+
+/// @cond ignore
+struct _OneWireBus_Timing
+{
+    uint32_t A, B, C, D, E, F, G, H, I, J;
+};
+//// @endcond
+
+// 1-Wire timing delays (standard) in microseconds.
+// Labels and values are from https://www.maximintegrated.com/en/app-notes/index.mvp/id/126
+static const struct _OneWireBus_Timing _StandardTiming = {
+        6,    // A - read/write "1" master pull DQ low duration
+        64,   // B - write "0" master pull DQ low duration
+        60,   // C - write "1" master pull DQ high duration
+        10,   // D - write "0" master pull DQ high duration
+        9,    // E - read master pull DQ high duration
+        55,   // F - complete read timeslot + 10ms recovery
+        0,    // G - wait before reset
+        480,  // H - master pull DQ low duration
+        70,   // I - master pull DQ high duration
+        410,  // J - complete presence timeslot + recovery
+};
+
+static void _us_delay(uint32_t time_us)
+{
+    ets_delay_us(time_us);
+}
+
+/**
+ * @brief Generate a 1-Wire reset (initialization).
+ * @param[in] bus Initialised bus instance.
+ * @param[out] is_present true if device is present, otherwise false.
+ * @return status
+ */
+static owb_status _reset(const OneWireBus * bus, bool * is_present)
+{
+    bool present = false;
+    portMUX_TYPE timeCriticalMutex = portMUX_INITIALIZER_UNLOCKED;
+    taskENTER_CRITICAL(&timeCriticalMutex);
+
+    gpio_set_direction(bus->gpio, GPIO_MODE_OUTPUT);
+    _us_delay(bus->timing->G);
+    gpio_set_level(bus->gpio, 0);  // Drive DQ low
+    _us_delay(bus->timing->H);
+    gpio_set_direction(bus->gpio, GPIO_MODE_INPUT); // Release the bus
+    gpio_set_level(bus->gpio, 1);  // Reset the output level for the next output
+    _us_delay(bus->timing->I);
+
+#ifdef PHY_DEBUG
+    gpio_set_level(PHY_DEBUG_GPIO, 1);
+#endif
+
+    int level1 = gpio_get_level(bus->gpio);
+
+#ifdef PHY_DEBUG
+    gpio_set_level(PHY_DEBUG_GPIO, 0);
+#endif
+
+    _us_delay(bus->timing->J);   // Complete the reset sequence recovery
+
+#ifdef PHY_DEBUG
+    gpio_set_level(PHY_DEBUG_GPIO, 1);
+#endif
+
+    int level2 = gpio_get_level(bus->gpio);
+
+#ifdef PHY_DEBUG
+    gpio_set_level(PHY_DEBUG_GPIO, 0);
+#endif
+
+    taskEXIT_CRITICAL(&timeCriticalMutex);
+
+    present = (level1 == 0) && (level2 == 1);   // Sample for presence pulse from slave
+    ESP_LOGD(TAG, "reset: level1 0x%x, level2 0x%x, present %d", level1, level2, present);
+
+    *is_present = present;
+
+    return OWB_STATUS_OK;
+}
+
+/**
+ * @brief Send a 1-Wire write bit, with recovery time.
+ * @param[in] bus Initialised bus instance.
+ * @param[in] bit The value to send.
+ */
+static void _write_bit(const OneWireBus * bus, int bit)
+{
+    int delay1 = bit ? bus->timing->A : bus->timing->C;
+    int delay2 = bit ? bus->timing->B : bus->timing->D;
+
+    portMUX_TYPE timeCriticalMutex = portMUX_INITIALIZER_UNLOCKED;
+    taskENTER_CRITICAL(&timeCriticalMutex);
+
+    gpio_set_direction(bus->gpio, GPIO_MODE_OUTPUT);
+    gpio_set_level(bus->gpio, 0);  // Drive DQ low
+    _us_delay(delay1);
+    gpio_set_level(bus->gpio, 1);  // Release the bus
+    _us_delay(delay2);
+
+    taskEXIT_CRITICAL(&timeCriticalMutex);
+}
+
+/**
+ * @brief Read a bit from the 1-Wire bus and return the value, with recovery time.
+ * @param[in] bus Initialised bus instance.
+ */
+static int _read_bit(const OneWireBus * bus)
+{
+    int result = 0;
+
+    portMUX_TYPE timeCriticalMutex = portMUX_INITIALIZER_UNLOCKED;
+    taskENTER_CRITICAL(&timeCriticalMutex);
+
+    gpio_set_direction(bus->gpio, GPIO_MODE_OUTPUT);
+    gpio_set_level(bus->gpio, 0);  // Drive DQ low
+    _us_delay(bus->timing->A);
+    gpio_set_direction(bus->gpio, GPIO_MODE_INPUT); // Release the bus
+    gpio_set_level(bus->gpio, 1);  // Reset the output level for the next output
+    _us_delay(bus->timing->E);
+
+#ifdef PHY_DEBUG
+    gpio_set_level(PHY_DEBUG_GPIO, 1);
+#endif
+
+    int level = gpio_get_level(bus->gpio);
+
+#ifdef PHY_DEBUG
+    gpio_set_level(PHY_DEBUG_GPIO, 0);
+#endif
+
+    _us_delay(bus->timing->F);   // Complete the timeslot and 10us recovery
+
+    taskEXIT_CRITICAL(&timeCriticalMutex);
+
+    result = level & 0x01;
+
+    return result;
+}
+
+/**
+ * @brief Write 1-Wire data byte.
+ * @param[in] bus Initialised bus instance.
+ * @param[in] data Value to write.
+ */
+static void _write_byte(const OneWireBus * bus, uint8_t data)
+{
+    ESP_LOGD(TAG, "write 0x%02x", data);
+    for (int i = 0; i < 8; ++i)
+    {
+        _write_bit(bus, data & 0x01);
+        data >>= 1;
+    }
+}
+
+/**
+ * @brief Read 1-Wire data byte from  bus.
+ * @param[in] bus Initialised bus instance.
+ * @return Byte value read from bus.
+ */
+static uint8_t _read_byte(const OneWireBus * bus)
+{
+    uint8_t result = 0;
+    for (int i = 0; i < 8; ++i)
+    {
+        result >>= 1;
+        if (_read_bit(bus))
+        {
+            result |= 0x80;
+        }
+    }
+    ESP_LOGD(TAG, "read 0x%02x", result);
+    return result;
+}
+
+/**
+ * @param Read a block of bytes from 1-Wire bus.
+ * @param[in] bus Initialised bus instance.
+ * @param[in,out] buffer Pointer to buffer to receive read data.
+ * @param[in] len Number of bytes to read, must not exceed length of receive buffer.
+ * @return status
+ */
+static owb_status _read_block(const OneWireBus * bus, uint8_t * buffer, unsigned int len)
+{
+    for (int i = 0; i < len; ++i)
+    {
+        *buffer++ = _read_byte(bus);
+    }
+
+    return OWB_STATUS_OK;
+}
+
+/**
+ * @param Write a block of bytes from 1-Wire bus.
+ * @param[in] bus Initialised bus instance.
+ * @param[in] buffer Pointer to buffer to write data from.
+ * @param[in] len Number of bytes to write.
+ * @return status
+ */
+static owb_status _write_block(const OneWireBus * bus, const uint8_t * buffer, unsigned int len)
+{
+    for (int i = 0; i < len; ++i)
+    {
+        _write_byte(bus, buffer[i]);
+    }
+
+    return OWB_STATUS_OK;
+}
+
+/* @param[out] is_found true if a device was found, false if not
+ * @return status
+ */
+static owb_status _search(const OneWireBus * bus, OneWireBus_SearchState * state, bool *is_found)
+{
+    // Based on https://www.maximintegrated.com/en/app-notes/index.mvp/id/187
+
+    // initialize for search
+    int id_bit_number = 1;
+    int last_zero = 0;
+    int rom_byte_number = 0;
+    int id_bit = 0;
+    int cmp_id_bit = 0;
+    uint8_t rom_byte_mask = 1;
+    uint8_t search_direction = 0;
+    bool search_result = false;
+    uint8_t crc8 = 0;
+    owb_status status;
+
+    // if the last call was not the last one
+    if (!state->last_device_flag)
+    {
+        // 1-Wire reset
+        bool is_present;
+        _reset(bus, &is_present);
+        if (!is_present)
+        {
+            // reset the search
+            state->last_discrepancy = 0;
+            state->last_device_flag = false;
+            state->last_family_discrepancy = 0;
+            *is_found = false;
+            return OWB_STATUS_OK;
+        }
+
+        // issue the search command
+        _write_byte(bus, OWB_ROM_SEARCH);
+
+        // loop to do the search
+        do
+        {
+            // read a bit and its complement
+            id_bit = _read_bit(bus);
+            cmp_id_bit = _read_bit(bus);
+
+            // check for no devices on 1-wire
+            if ((id_bit == 1) && (cmp_id_bit == 1))
+                break;
+            else
+            {
+                // all devices coupled have 0 or 1
+                if (id_bit != cmp_id_bit)
+                    search_direction = id_bit;  // bit write value for search
+                else
+                {
+                    // if this discrepancy if before the Last Discrepancy
+                    // on a previous next then pick the same as last time
+                    if (id_bit_number < state->last_discrepancy)
+                        search_direction = ((state->rom_code.bytes[rom_byte_number] & rom_byte_mask) > 0);
+                    else
+                        // if equal to last pick 1, if not then pick 0
+                        search_direction = (id_bit_number == state->last_discrepancy);
+
+                    // if 0 was picked then record its position in LastZero
+                    if (search_direction == 0)
+                    {
+                        last_zero = id_bit_number;
+
+                        // check for Last discrepancy in family
+                        if (last_zero < 9)
+                            state->last_family_discrepancy = last_zero;
+                    }
+                }
+
+                // set or clear the bit in the ROM byte rom_byte_number
+                // with mask rom_byte_mask
+                if (search_direction == 1)
+                    state->rom_code.bytes[rom_byte_number] |= rom_byte_mask;
+                else
+                    state->rom_code.bytes[rom_byte_number] &= ~rom_byte_mask;
+
+                // serial number search direction write bit
+                _write_bit(bus, search_direction);
+
+                // increment the byte counter id_bit_number
+                // and shift the mask rom_byte_mask
+                id_bit_number++;
+                rom_byte_mask <<= 1;
+
+                // if the mask is 0 then go to new SerialNum byte rom_byte_number and reset mask
+                if (rom_byte_mask == 0)
+                {
+                    crc8 = owb_crc8_byte(crc8, state->rom_code.bytes[rom_byte_number]);  // accumulate the CRC
+                    rom_byte_number++;
+                    rom_byte_mask = 1;
+                }
+            }
+        }
+        while(rom_byte_number < 8);  // loop until through all ROM bytes 0-7
+
+        // if the search was successful then
+        if (!((id_bit_number < 65) || (crc8 != 0)))
+        {
+            // search successful so set LastDiscrepancy,LastDeviceFlag,search_result
+            state->last_discrepancy = last_zero;
+
+            // check for last device
+            if (state->last_discrepancy == 0)
+                state->last_device_flag = true;
+
+            search_result = true;
+        }
+    }
+
+    // if no device found then reset counters so next 'search' will be like a first
+    if (!search_result || !state->rom_code.bytes[0])
+    {
+        state->last_discrepancy = 0;
+        state->last_device_flag = false;
+        state->last_family_discrepancy = 0;
+        search_result = false;
+    }
+
+    status = OWB_STATUS_OK;
+
+    *is_found = search_result;
+
+    return status;
+}
+
+owb_status _init(OneWireBus * bus, int gpio)
+{
+    owb_status status;
+
+    if (bus != NULL)
+    {
+        bus->gpio = gpio;
+        bus->timing = &_StandardTiming;
+
+        // platform specific:
+        gpio_pad_select_gpio(bus->gpio);
+
+#ifdef PHY_DEBUG
+        gpio_config_t io_conf;
+        io_conf.intr_type = GPIO_INTR_DISABLE;
+        io_conf.mode = GPIO_MODE_OUTPUT;
+        io_conf.pin_bit_mask = PHY_DEBUG_GPIO_MASK;
+        io_conf.pull_down_en = GPIO_PULLDOWN_ENABLE;
+        io_conf.pull_up_en = GPIO_PULLUP_DISABLE;
+        ESP_ERROR_CHECK(gpio_config(&io_conf));
+#endif
+
+        status = OWB_STATUS_OK;
+    }
+    else
+    {
+        ESP_LOGE(TAG, "bus is NULL");
+        status = OWB_STATUS_ERR;
+    }
+
+    return status;
+}
+
+static struct owb_driver gpio_driver =
+{
+    .name = "owb_gpio",
+    .init = _init,
+    .search = _search,
+    .reset = _reset,
+    .write_bytes = _write_block,
+    .read_bytes = _read_block
+};
+
+const struct owb_driver* owb_gpio_get_driver()
+{
+    return &gpio_driver;
+}

--- a/owb_gpio.c
+++ b/owb_gpio.c
@@ -237,7 +237,7 @@ static uint8_t _read_byte(const OneWireBus * bus)
  * @param[in] len Number of bytes to read, must not exceed length of receive buffer.
  * @return status
  */
-static owb_status _read_block(const OneWireBus * bus, uint8_t * buffer, unsigned int len)
+static owb_status _read_block(const OneWireBus * bus, uint8_t * buffer, size_t len)
 {
     for (int i = 0; i < len; ++i)
     {
@@ -254,7 +254,7 @@ static owb_status _read_block(const OneWireBus * bus, uint8_t * buffer, unsigned
  * @param[in] len Number of bytes to write.
  * @return status
  */
-static owb_status _write_block(const OneWireBus * bus, const uint8_t * buffer, unsigned int len)
+static owb_status _write_block(const OneWireBus * bus, const uint8_t * buffer, size_t len)
 {
     for (int i = 0; i < len; ++i)
     {

--- a/owb_gpio.h
+++ b/owb_gpio.h
@@ -1,0 +1,3 @@
+#pragma once
+
+struct owb_driver* owb_gpio_get_driver();


### PR DESCRIPTION
The latest commit doesn't work. I'm having trouble figuring out how to resolve the requirements of passing parameters to the specific driver initialization function, as these could differ and storing the driver specific parameters along with the function pointer table.

Ideas for how to properly handle this in c? I'm sure it can be done but it isn't clear to me how.

Other options include making the gpio/rmt support a compile time setting, that would simplify the implementation greatly, or dropping the gpio support entirely. I'm not sure there is much benefit to keeping the gpio implementation when the rmt implementation is in place, especially given the number of rmt channels available.