### PR TITLE
Renaming the attribute "Name" to lower case

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,5 +1,5 @@
 {
-  "name": "ESP32-OWB",
+  "name": "esp32-owb",
   "keywords": "onewire, 1-wire, bus, sensor, temperature",
   "description": "ESP32-compatible C component for the Maxim Integrated 1-Wire protocol.",
   "repository":


### PR DESCRIPTION
Reason:
  - name of gitrepo also in lower-case 
  - dependencies in https://github.com/DavidAntliff/esp32-ds18b20 also in lower-case