### PR TITLE
Explicitly select clock source

### DIFF
--- a/owb_rmt.c
+++ b/owb_rmt.c
@@ -384,6 +384,7 @@ static owb_status _init(owb_rmt_driver_info *info, gpio_num_t gpio_num,
     rmt_tx.rmt_mode = RMT_MODE_TX;
     if (rmt_config(&rmt_tx) == ESP_OK)
     {
+        rmt_set_source_clk(info->tx_channel, RMT_BASECLK_APB);  // only APB is supported by IDF 4.2
         if (rmt_driver_install(rmt_tx.channel, 0, ESP_INTR_FLAG_LOWMED | ESP_INTR_FLAG_IRAM | ESP_INTR_FLAG_SHARED) == ESP_OK)
         {
             rmt_config_t rmt_rx = {0};
@@ -397,6 +398,7 @@ static owb_status _init(owb_rmt_driver_info *info, gpio_num_t gpio_num,
             rmt_rx.rx_config.idle_threshold = OW_DURATION_RX_IDLE;
             if (rmt_config(&rmt_rx) == ESP_OK)
             {
+                rmt_set_source_clk(info->rx_channel, RMT_BASECLK_APB);  // only APB is supported by IDF 4.2
                 if (rmt_driver_install(rmt_rx.channel, 512, ESP_INTR_FLAG_LOWMED | ESP_INTR_FLAG_IRAM | ESP_INTR_FLAG_SHARED) == ESP_OK)
                 {
                     rmt_get_ringbuf_handle(info->rx_channel, &info->rb);


### PR DESCRIPTION
I've been chasing a bug that appeared when upgrading from IDF 3.3 to 4.2. OWB stopped working, because the reset pulse was 38.4ms long, 80 times longer than it should be.
I still don't understand why, but apparently the clock source for some RMT channels is changed.

This PR explicitly select the APB (80MHz) clock for use. The APB is currently the only clock source supported by IDF.