### PR TITLE
Switch RMT clock source to 1MHz REF

### DIFF
--- a/include/owb_rmt.h
+++ b/include/owb_rmt.h
@@ -39,6 +39,22 @@
 #include "freertos/queue.h"
 #include "freertos/ringbuf.h"
 #include "driver/rmt.h"
+#include "soc/soc_caps.h"
+
+#ifdef SOC_RMT_SUPPORT_REF_TICK
+#define RMT_BASECLK_SRC RMT_BASECLK_REF
+#define RMT_CLK_DIV 1
+
+#elif SOC_RMT_SUPPORT_XTAL
+#define RMT_BASECLK_SRC RMT_BASECLK_XTAL
+#define RMT_CLK_DIV 40
+
+#else
+#define RMT_BASECLK_SRC RMT_BASECLK_APB
+#define RMT_CLK_DIV 80
+
+#endif
+
 
 #ifdef __cplusplus
 extern "C" {

--- a/owb_rmt.c
+++ b/owb_rmt.c
@@ -376,7 +376,7 @@ static owb_status _init(owb_rmt_driver_info *info, gpio_num_t gpio_num,
     rmt_tx.channel = info->tx_channel;
     rmt_tx.gpio_num = gpio_num;
     rmt_tx.mem_block_num = 1;
-    rmt_tx.clk_div = 80;
+    rmt_tx.clk_div = 1;
     rmt_tx.tx_config.loop_en = false;
     rmt_tx.tx_config.carrier_en = false;
     rmt_tx.tx_config.idle_level = 1;
@@ -384,13 +384,13 @@ static owb_status _init(owb_rmt_driver_info *info, gpio_num_t gpio_num,
     rmt_tx.rmt_mode = RMT_MODE_TX;
     if (rmt_config(&rmt_tx) == ESP_OK)
     {
-        rmt_set_source_clk(info->tx_channel, RMT_BASECLK_APB);  // only APB is supported by IDF 4.2
+        rmt_set_source_clk(info->tx_channel, RMT_BASECLK_REF);
         if (rmt_driver_install(rmt_tx.channel, 0, ESP_INTR_FLAG_LOWMED | ESP_INTR_FLAG_IRAM | ESP_INTR_FLAG_SHARED) == ESP_OK)
         {
             rmt_config_t rmt_rx = {0};
             rmt_rx.channel = info->rx_channel;
             rmt_rx.gpio_num = gpio_num;
-            rmt_rx.clk_div = 80;
+            rmt_rx.clk_div = 1;
             rmt_rx.mem_block_num = 1;
             rmt_rx.rmt_mode = RMT_MODE_RX;
             rmt_rx.rx_config.filter_en = true;
@@ -398,7 +398,7 @@ static owb_status _init(owb_rmt_driver_info *info, gpio_num_t gpio_num,
             rmt_rx.rx_config.idle_threshold = OW_DURATION_RX_IDLE;
             if (rmt_config(&rmt_rx) == ESP_OK)
             {
-                rmt_set_source_clk(info->rx_channel, RMT_BASECLK_APB);  // only APB is supported by IDF 4.2
+                rmt_set_source_clk(info->rx_channel, RMT_BASECLK_REF);
                 if (rmt_driver_install(rmt_rx.channel, 512, ESP_INTR_FLAG_LOWMED | ESP_INTR_FLAG_IRAM | ESP_INTR_FLAG_SHARED) == ESP_OK)
                 {
                     rmt_get_ringbuf_handle(info->rx_channel, &info->rb);

--- a/owb_rmt.c
+++ b/owb_rmt.c
@@ -370,7 +370,7 @@ static owb_status _init(owb_rmt_driver_info *info, gpio_num_t gpio_num,
 #ifdef OW_DEBUG
     ESP_LOGI(TAG, "RMT TX channel: %d", info->tx_channel);
     ESP_LOGI(TAG, "RMT RX channel: %d", info->rx_channel);
-	ESP_LOGI(TAG, "RMT CLK_DIV: %d, BASECLK_SRC: %d", RMT_CLK_DIV, RMT_BASECLK_SRC);
+    ESP_LOGI(TAG, "RMT CLK_DIV: %d, BASECLK_SRC: %d", RMT_CLK_DIV, RMT_BASECLK_SRC);
 #endif
 
     rmt_config_t rmt_tx = {0};

--- a/owb_rmt.c
+++ b/owb_rmt.c
@@ -376,7 +376,7 @@ static owb_status _init(owb_rmt_driver_info *info, gpio_num_t gpio_num,
     rmt_tx.channel = info->tx_channel;
     rmt_tx.gpio_num = gpio_num;
     rmt_tx.mem_block_num = 1;
-    rmt_tx.clk_div = 1;
+    rmt_tx.clk_div = RMT_CLK_DIV;
     rmt_tx.tx_config.loop_en = false;
     rmt_tx.tx_config.carrier_en = false;
     rmt_tx.tx_config.idle_level = 1;
@@ -384,13 +384,13 @@ static owb_status _init(owb_rmt_driver_info *info, gpio_num_t gpio_num,
     rmt_tx.rmt_mode = RMT_MODE_TX;
     if (rmt_config(&rmt_tx) == ESP_OK)
     {
-        rmt_set_source_clk(info->tx_channel, RMT_BASECLK_REF);
+        rmt_set_source_clk(info->tx_channel, RMT_BASECLK_SRC);
         if (rmt_driver_install(rmt_tx.channel, 0, ESP_INTR_FLAG_LOWMED | ESP_INTR_FLAG_IRAM | ESP_INTR_FLAG_SHARED) == ESP_OK)
         {
             rmt_config_t rmt_rx = {0};
             rmt_rx.channel = info->rx_channel;
             rmt_rx.gpio_num = gpio_num;
-            rmt_rx.clk_div = 1;
+            rmt_rx.clk_div = RMT_CLK_DIV;
             rmt_rx.mem_block_num = 1;
             rmt_rx.rmt_mode = RMT_MODE_RX;
             rmt_rx.rx_config.filter_en = true;
@@ -398,7 +398,7 @@ static owb_status _init(owb_rmt_driver_info *info, gpio_num_t gpio_num,
             rmt_rx.rx_config.idle_threshold = OW_DURATION_RX_IDLE;
             if (rmt_config(&rmt_rx) == ESP_OK)
             {
-                rmt_set_source_clk(info->rx_channel, RMT_BASECLK_REF);
+                rmt_set_source_clk(info->rx_channel, RMT_BASECLK_SRC);
                 if (rmt_driver_install(rmt_rx.channel, 512, ESP_INTR_FLAG_LOWMED | ESP_INTR_FLAG_IRAM | ESP_INTR_FLAG_SHARED) == ESP_OK)
                 {
                     rmt_get_ringbuf_handle(info->rx_channel, &info->rb);

--- a/owb_rmt.c
+++ b/owb_rmt.c
@@ -370,6 +370,7 @@ static owb_status _init(owb_rmt_driver_info *info, gpio_num_t gpio_num,
 #ifdef OW_DEBUG
     ESP_LOGI(TAG, "RMT TX channel: %d", info->tx_channel);
     ESP_LOGI(TAG, "RMT RX channel: %d", info->rx_channel);
+	ESP_LOGI(TAG, "RMT CLK_DIV: %d, BASECLK_SRC: %d", RMT_CLK_DIV, RMT_BASECLK_SRC);
 #endif
 
     rmt_config_t rmt_tx = {0};


### PR DESCRIPTION
Hello,

When using Dynamic Frequency Scaling to reduce power consumption, the APB clock used by RMT changes between max_freq_mhz and min_freq_mhz (typicaly between 80 and 10MHz). This causes errors when using the RMT peripheral for 1wire communication.

We could use either the 1Mhz REF or 40Mhz XTAL clock sources instead, they are stable even during DFS operation:

```
#if SOC_RMT_SUPPORT_REF_TICK
    RMT_BASECLK_REF = 0, /*!< RMT source clock is REF_TICK, 1MHz by default */
#endif
    RMT_BASECLK_APB = 1, /*!< RMT source clock is APB CLK, 80Mhz by default */
#if SOC_RMT_SUPPORT_XTAL
    RMT_BASECLK_XTAL = 3, /*!< RMT source clock is XTAL clock, 40Mhz by default */
#endif
```

Here is the availability of various clock sources depending on target device:
| RMT_BASECLK_REF  | RMT_BASECLK_APB | RMT_BASECLK_XTAL |
| ------------- | ------------- | ------------- |
| ESP32  | ESP32 |  |
| ESP32-S2  | ESP32-S2 | |
| | ESP32-S3 | ESP32-S3 |
| | ESP32-C3 | ESP32-C3 |

I am a bit puzzled that the documentation still states:
`REF tick clock, which would be 1Mhz (not supported in this version).`
When using this has clear benefits. Perhaps they just forgot to remove this?

We should probably have the clock source selected automatically based on the target device, not hard-coded. My patch is just for demonstration purposes.

What do you think?

